### PR TITLE
Add and set CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.19)
 project(OpenALpp)
 
 option(OALPP_ENABLE_UNIT_TESTS "Enable unit tests" ON)
+option(OALPP_ENABLE_INTEGRATION_TESTS "Enable integration tests" ON)
 
 if (MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /EHsc")

--- a/ext/libnyquist/CMakeLists.txt
+++ b/ext/libnyquist/CMakeLists.txt
@@ -1,6 +1,8 @@
 message(STATUS "Fetching libnyquist")
 include(FetchContent)
 
+set(BUILD_EXAMPLE OFF CACHE BOOL "")
+
 FetchContent_Declare(
         libnyquist
         GIT_REPOSITORY https://github.com/ddiakopoulos/libnyquist

--- a/ext/openal-soft/CMakeLists.txt
+++ b/ext/openal-soft/CMakeLists.txt
@@ -1,9 +1,14 @@
 message(STATUS "Fetching openal-soft")
 include(FetchContent)
 
+set(ALSOFT_UTILS OFF CACHE BOOL "")
+set(ALSOFT_EXAMPLES OFF CACHE BOOL "")
+set(ALSOFT_UPDATE_BUILD_VERSION OFF CACHE BOOL "")
+
 FetchContent_Declare(
         openal-soft
         GIT_REPOSITORY https://github.com/kcat/openal-soft
         GIT_TAG 1.21.1
 )
+
 FetchContent_MakeAvailable(openal-soft)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,2 +1,7 @@
-add_subdirectory(integration)
-add_subdirectory(unit_tests)
+if (OALPP_ENABLE_INTEGRATION_TESTS)
+    add_subdirectory(integration)
+endif ()
+
+if (OALPP_ENABLE_UNIT_TESTS)
+    add_subdirectory(unit_tests)
+endif ()


### PR DESCRIPTION
Add CMake options to control test target creation and set default options for externals to prevent build configuration pollution.